### PR TITLE
Perform v9 migration less-atomically

### DIFF
--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v9.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v9.rs
@@ -76,12 +76,10 @@ pub fn upgrade_to_v9<T: BeaconChainTypes>(
     if current_epoch >= bellatrix_fork_epoch {
         info!(
             log,
-            "Upgrading database schema to v9 by re-writing blocks";
-            "info" => "This will take several minutes and use a *lot* of RAM. \
-                       You cannot downgrade once it completes, but it is safe to exit before \
-                       completion (Ctrl-C now). If your machine doesn't have enough RAM to run \
-                       the migration then you will have to re-sync. This will only be necessary \
-                       on Kiln and merge testnets, never Prater or mainnet."
+            "Upgrading database schema to v9";
+            "info" => "This will take several minutes. Each block will be read from and \
+                       re-written to the database. You may safely exit now (Ctrl-C) and resume \
+                       the migration later. Downgrading is no longer possible."
         );
 
         for res in db.hot_db.iter_column_keys(DBColumn::BeaconBlock) {

--- a/beacon_node/store/src/errors.rs
+++ b/beacon_node/store/src/errors.rs
@@ -44,6 +44,7 @@ pub enum Error {
     AddPayloadLogicError,
     ResyncRequiredForExecutionPayloadSeparation,
     SlotClockUnavailableForMigration,
+    V9MigrationFailure(Hash256),
 }
 
 pub trait HandleUnavailable<T> {

--- a/beacon_node/store/src/leveldb_store.rs
+++ b/beacon_node/store/src/leveldb_store.rs
@@ -197,6 +197,28 @@ impl<E: EthSpec> KeyValueStore<E> for LevelDB<E> {
                 }),
         )
     }
+
+    /// Iterate through all keys and values in a particular column.
+    fn iter_column_keys(&self, column: DBColumn) -> ColumnKeyIter {
+        let start_key =
+            BytesKey::from_vec(get_key_for_col(column.into(), Hash256::zero().as_bytes()));
+
+        let iter = self.db.keys_iter(self.read_options());
+        iter.seek(&start_key);
+
+        Box::new(
+            iter.take_while(move |key| key.matches_column(column))
+                .map(move |bytes_key| {
+                    let key =
+                        bytes_key
+                            .remove_column(column)
+                            .ok_or(HotColdDBError::IterationError {
+                                unexpected_key: bytes_key,
+                            })?;
+                    Ok(key)
+                }),
+        )
+    }
 }
 
 impl<E: EthSpec> ItemStore<E> for LevelDB<E> {}

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -43,6 +43,7 @@ use strum::{EnumString, IntoStaticStr};
 pub use types::*;
 
 pub type ColumnIter<'a> = Box<dyn Iterator<Item = Result<(Hash256, Vec<u8>), Error>> + 'a>;
+pub type ColumnKeyIter<'a> = Box<dyn Iterator<Item = Result<Hash256, Error>> + 'a>;
 
 pub trait KeyValueStore<E: EthSpec>: Sync + Send + Sized + 'static {
     /// Retrieve some bytes in `column` with `key`.
@@ -77,8 +78,14 @@ pub trait KeyValueStore<E: EthSpec>: Sync + Send + Sized + 'static {
     /// Compact the database, freeing space used by deleted items.
     fn compact(&self) -> Result<(), Error>;
 
-    /// Iterate through all values in a particular column.
+    /// Iterate through all keys and values in a particular column.
     fn iter_column(&self, _column: DBColumn) -> ColumnIter {
+        // Default impl for non LevelDB databases
+        Box::new(std::iter::empty())
+    }
+
+    /// Iterate through all keys in a particular column.
+    fn iter_column_keys(&self, _column: DBColumn) -> ColumnKeyIter {
         // Default impl for non LevelDB databases
         Box::new(std::iter::empty())
     }


### PR DESCRIPTION
## Issue Addressed

Performs each block in the migration separately, rather than the entire operation. This helps to reduce the memory footprint of this operation from ~10GB to ~1GB.

Some new logic has been added to detect when a block has already been migrated, this allows recovery from a partial migration (e.g., Ctrl+C halfway through the migration).

I've swapped iterating the keys of the database rather than keys + values. This isn't strictly necessary and I'm not sure if it has an impact on memory usage, but I've kept it around since:

1. Using keys allows us to re-use existing DB methods (e.g., `try_get_full_block`) rather than dealing with SSZ bytes directly.
1. It seems cool to have the key iterator in the code for future migrations.

I'm not attached to the key iterator though, I could take it or leave it.