### PR TITLE
Update milhouse to Mac's branch without vecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5165,7 +5165,7 @@ dependencies = [
 [[package]]
 name = "milhouse"
 version = "0.1.0"
-source = "git+https://github.com/sigp/milhouse?branch=main#e30719aaf1e4b46e3ff1962f7370965e68fa548b"
+source = "git+http://github.com/macladson/milhouse.git?branch=dedup-packed-leaf#33ebf5c7e74112f48240b64377958675cdbef8bd"
 dependencies = [
  "arbitrary",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ ethereum-consensus = { git = "https://github.com/ralexstokes//ethereum-consensus
 [patch."https://github.com/ralexstokes/ssz-rs"]
 ssz-rs = { git = "https://github.com/ralexstokes//ssz-rs", rev = "adf1a0b14cef90b9536f28ef89da1fab316465e1" }
 
+[patch."https://github.com/sigp/milhouse"]
+milhouse = { git = "http://github.com/macladson/milhouse.git", branch = "dedup-packed-leaf" }
+
 [profile.maxperf]
 inherits = "release"
 lto = "fat"


### PR DESCRIPTION
Temp branch for benchmarking

Build:

```
PROFILE=maxperf FEATURES=jemalloc make install-lcli
```

Run:

```
RUST_LOG=debug lcli transition-blocks --block-path block.ssz --pre-state-path state.ssz --exclude-cache-builds --no-signature-verification --runs 50
```

Block used is from slot 6721513: https://drive.google.com/file/d/1B-D7HnYbsNTeLrr-zvZpKA43jfs_BYRN/view?usp=sharing

State is one slot prior at 6721512: https://drive.google.com/file/d/1MdadQNdpFT40XvWQft2kKTpT4a9tyfTR/view?usp=sharing